### PR TITLE
Major update

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@ fixtures:
   repositories:
     stdlib:  https://github.com/puppetlabs/puppetlabs-stdlib
     powershell:  https://github.com/puppetlabs/puppetlabs-powershell
-    win_facts:  https://github.com/liamjbennett/puppet-win_facts
-    download_file: https://github.com/opentable/puppet-download_file
+    remote_file: https://github.com/lwf/puppet-remote_file
   symlinks:
     dotnet: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ Gemfile.lock
 Gemfile.local
 vendor/
 .vendor/
-spec/fixtures/
+spec/fixtures/manifests/
+spec/fixtures/modules/
 .vagrant/
 .bundle/
 coverage/

--- a/.msync.yml
+++ b/.msync.yml
@@ -1,1 +1,1 @@
-modulesync_config_version: '0.12.1'
+modulesync_config_version: '0.12.6'

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,2 +1,24 @@
 .travis.yml:
   secure: "PdMTOaqZNzov5xJP0ltbYsybw++lSgiTxS8S/MtynQfljMm/EbeReuMbEhSuAjtro5gobNkJhD+EDkx5jnDCF5SgksWJ9TCP9DjDUtHe37aDkRyrWA5cAupUbGqFCquhYdSYTqRmvPZpwPxFKmmo/6ycLyM1CKT0SqTO2nVmCxM="
+  includes:
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
+  - rvm: 2.2.5
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
+  - rvm: 2.3.1
+    env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
+  - rvm: 2.3.1
+    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
+  - rvm: 2.3.1
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
+  - rvm: 2.4.0-preview1
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
+Gemfile:
+  puppet_version: "~> 4.0"
+Rakefile:
+  extra_disabled_lint_checks:
+    - disable_relative_classname_inclusion # This is a Puppet 4.x only module. There is no such thing as a relative classname.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test FUTURE_PARSER="yes"
   - rvm: 2.1
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test FUTURE_PARSER="yes"
   - rvm: 2.1
     env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,28 +16,28 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test FUTURE_PARSER="yes"
-  - rvm: 2.1
-    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test FUTURE_PARSER="yes"
-  - rvm: 2.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
+  - rvm: 2.2.5
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=build
+    env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
+    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.4.0-preview1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
   allow_failures:
     - rvm: 2.4.0-preview1
 notifications:
   email: false
 deploy:
   provider: puppetforge
-  edge:
+  deploy:
     branch: ha-bug-puppet-forge
   user: puppet
   password:
@@ -46,5 +46,5 @@ deploy:
     tags: true
     # all_branches is required to use tags
     all_branches: true
-    # Only publish if our main Ruby target builds
-    rvm: 2.3.1
+    # Only publish the build marked with "DEPLOY_TO_FORGE"
+    condition: "$DEPLOY_TO_FORGE = yes"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'puppetlabs_spec_helper',                                     :require => false
+  gem 'puppetlabs_spec_helper', '~> 1.2.2',                         :require => false
   gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
@@ -28,7 +28,6 @@ group :test do
   gem 'puppet-strings',                                             :require => false, :git => 'https://github.com/puppetlabs/puppetlabs-strings.git'
   gem 'rubocop-rspec', '~> 1.6',                                    :require => false if RUBY_VERSION >= '2.3.0'
   gem 'json_pure', '<= 2.0.1',                                      :require => false if RUBY_VERSION < '2.0.0'
-  gem 'puppet-lint', '2.0.0',                                       :require => false
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Ensures the state of .net on the system. Present or Absent.
 The version of .net that you want to be managed by this definition.
 
 #####`package_dir`
-If installing .NET from a directory or a mounted network location then this is that directory
+If installing .NET from a directory or a mounted network location then this is
+that directory. If the version of .NET being installed is a Windows feature, it
+may sometimes be necessary to specify package\_dir as the path to installation
+media, such as `D:\sources\sxs`.
 
 ##Reference
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.send('disable_relative_classname_inclusion')
 
 exclude_paths = %w(
   pkg/**/*
@@ -34,11 +35,9 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-desc 'Run tests metadata_lint, lint, syntax, spec'
+desc 'Run tests metadata_lint, release_checks'
 task test: [
   :metadata_lint,
-  :lint,
-  :syntax,
-  :spec,
+  :release_checks,
 ]
 # vim: syntax=ruby

--- a/manifests/install/dism.pp
+++ b/manifests/install/dism.pp
@@ -1,0 +1,23 @@
+#
+define dotnet::install::dism (
+  $ensure  = 'present',
+  $version = '',
+) {
+
+  if $ensure == 'present' {
+    exec { "install-dotnet-dism-${version}":
+      command   => 'DISM /Online /Enable-Feature /FeatureName:NetFx3 /NoRestart',
+      creates   => "C:/Windows/Microsoft.NET/Framework/v${version}",
+      provider  => powershell,
+      logoutput => true,
+    }
+  } else {
+    exec { "uninstall-dotnet-dism-${version}":
+      command   => 'DISM /Online /Disable-Feature /FeatureName:NetFx3 /NoRestart',
+      onlyif    => "If (-Not(Test-Path C:/Windows/Microsoft.NET/Framework/v${version})) { Exit 1 }",
+      provider  => powershell,
+      logoutput => true,
+    }
+  }
+
+}

--- a/manifests/install/feature.pp
+++ b/manifests/install/feature.pp
@@ -1,22 +1,29 @@
 #
 define dotnet::install::feature(
-  $ensure = 'present',
-  $version = ''
+  $version,
+  $ensure  = 'present',
+  $feature = 'AS-NET-Framework',
+  $source  = undef,
 ) {
 
+  $source_flag = $source ? {
+    undef   => '',
+    default => "-source ${source}",
+  }
+
   if $ensure == 'present' {
-    exec { "install-feature-${version}":
-      command   => 'Import-Module ServerManager; Add-WindowsFeature as-net-framework',
+    exec { "install-dotnet-feature-${version}":
+      command   => "Import-Module ServerManager; Add-WindowsFeature ${feature} ${source_flag}",
       provider  => powershell,
       logoutput => true,
-      unless    => "Test-Path C:\\Windows\\Microsoft.NET\\Framework\\v${version}",
+      creates   => "C:/Windows/Microsoft.NET/Framework/v${version}",
     }
   } else {
-    exec { "uninstall-feature-${version}":
-      command   => 'Import-Module ServerManager; Remove-WindowsFeature as-net-framework',
+    exec { "uninstall-dotnet-feature-${version}":
+      command   => "Import-Module ServerManager; Remove-WindowsFeature ${feature}",
       provider  => powershell,
       logoutput => true,
-      onlyif    => "Test-Path C:\\Windows\\Microsoft.NET\\Framework\\v${version}",
+      onlyif    => "If (-Not(Test-Path C:/Windows/Microsoft.NET/Framework/v${version})) { Exit 1 }",
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,29 +11,38 @@ class dotnet::params {
 
   $version = {
     '3.5' => {
-      'url' => 'http://download.microsoft.com/download/7/0/3/703455ee-a747-4cc8-bd3e-98a615c3aedb/dotNetFx35setup.exe',
-      'exe' => 'dotNetFx35setup.exe',
-      'key' => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{CE2CDD62-0124-36CA-84D3-9F4DCF5C5BD9}',
+      'url'       => 'http://download.microsoft.com/download/7/0/3/703455ee-a747-4cc8-bd3e-98a615c3aedb/dotNetFx35setup.exe',
+      'exe'       => 'dotNetFx35setup.exe',
+      'conflicts' => [ ],
+      'package'   => 'Microsoft .NET Framework 3.5',
     },
     '4.0' => {
-      'url' => 'http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe',
-      'exe' => 'dotNetFx40_Full_x86_x64.exe',
-      'key' => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{8E34682C-8118-31F1-BC4C-98CD9675E1C2}',
+      'url'       => 'http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe',
+      'exe'       => 'dotNetFx40_Full_x86_x64.exe',
+      'conflicts' => ['4.5', '4.5.1', '4.5.2'],
+      'package'   => [
+        'Microsoft .NET Framework 4 Extended',
+        'Microsoft .NET Framework 4 Client Profile',
+      ],
     },
-    '4.5' => {
-      'url' => 'http://download.microsoft.com/download/b/a/4/ba4a7e71-2906-4b2d-a0e1-80cf16844f5f/dotnetfx45_full_x86_x64.exe',
-      'exe' => 'dotnetfx45_full_x86_x64.exe',
-      'key' => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1AD147D0-BE0E-3D6C-AC11-64F6DC4163F1}',
+    '4.5'         => {
+      'url'       => 'http://download.microsoft.com/download/b/a/4/ba4a7e71-2906-4b2d-a0e1-80cf16844f5f/dotnetfx45_full_x86_x64.exe',
+      'exe'       => 'dotnetfx45_full_x86_x64.exe',
+      'conflicts' => ['4.0', '4.5.1', '4.5.2'],
+      'package'   => 'Microsoft .NET Framework 4.5',
     },
     '4.5.1' => {
-      'url' => 'http://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe',
-      'exe' => 'NDP451-KB2858728-x86-x64-AllOS-ENU.exe',
-      'key' => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{7DEBE4EB-6B40-3766-BB35-5CBBC385DA37}',
+      'url'       => 'http://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe',
+      'exe'       => 'NDP451-KB2858728-x86-x64-AllOS-ENU.exe',
+      'conflicts' => ['4.0', '4.5', '4.5.2'],
+      'package'   => 'Microsoft .NET Framework 4.5.1',
     },
     '4.5.2' => {
-      'url' => 'http://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe',
-      'exe' => 'NDP452-KB2901907-x86-x64-AllOS-ENU.exe',
-      'key' => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{26784146-6E05-3FF9-9335-786C7C0FB5BE}',
+      'url'       => 'http://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe',
+      'exe'       => 'NDP452-KB2901907-x86-x64-AllOS-ENU.exe',
+      'conflicts' => ['4.0', '4.5', '4.5.1'],
+      'package'   => 'Microsoft .NET Framework 4.5.2',
     },
   }
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,22 @@
 {
   "name":         "puppet-dotnet",
-  "version":      "1.0.2",
+  "version":      "2.0.0",
   "author":       "Vox Pupuli",
-  "license":      "MIT",
+  "license":      "Apache-2.0",
   "summary":      "'Module to manage the Microsoft .NET framework",
   "source":       "https://github.com/puppet-community/puppet-dotnet",
   "project_page": "https://github.com/puppet-community/puppet-dotnet",
   "issues_url":   "https://github.com/puppet-community/puppet-dotnet/issues",
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">=2015.2.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">=4.2.1"
+    }
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "windows",
@@ -15,20 +25,12 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 <5.0.0"
-    },
-    {
       "name": "puppetlabs/powershell",
       "version_requirement": ">= 1.0.0 <2.0.0"
     },
     {
-      "name": "liamjbennett/win_facts",
-      "version_requirement": ">= 0.0.1 <2.0.0"
-    },
-    {
-      "name": "puppet/download_file",
-      "version_requirement": ">= 1.0.0 <2.0.0"
+      "name": "lwf/remote_file",
+      "version_requirement": ">= 1.0.1 <2.0.0"
     }
   ]
 }

--- a/spec/defines/dotnet_spec.rb
+++ b/spec/defines/dotnet_spec.rb
@@ -1,38 +1,50 @@
 require 'spec_helper'
 
-describe 'dotnet', type: :define do
-  ['Windows Server 2012', 'Windows Server 2008 R2', 'Windows Server 2008', 'Windows Server 2003', 'Windows Server 2003 R2', 'Windows 8', 'Windows 7', 'Windows Vista', 'Windows XP'].each do |os|
-    context "with invalid custom param: os => #{os}, version => fubar" do
+describe 'dotnet', :type => :define do
+  ['2012', '2008 R2', '2008', '2003', '2003 R2', '8', '7', 'Vista', 'XP'].each do |release|
+    context "with invalid custom param: os.release.full => #{release}, version => fubar" do
       let(:title) { 'fubar' }
-      let(:params) do
-        { version: 'fubar' }
+      let :params do
+        { :version => 'fubar' }
       end
-      let(:facts) do
-        { operatingsystemversion: os }
+      let :facts do
+        { :os => { 'family' => 'windows', 'release' => { 'full' => release } } }
       end
 
       it do
-        expect do
-          should contain_exec('install-dotnet-3.5')
-        end.to raise_error(Puppet::Error)
+        expect { is_expected.to compile }.to raise_error(/parameter/)
       end
     end
   end
 
   ['Windows Server 2012', 'Windows Server 2008 R2', 'Windows Server 2008', 'Windows Server 2003', 'Windows Server 2003 R2', 'Windows 8', 'Windows 7', 'Windows Vista', 'Windows XP'].each do |os|
     context "with invalid custom param: os => #{os}, ensure => fubar" do
-      let(:title) { 'fubar' }
-      let(:params) do
-        { version: '3.5', ensure: 'fubar' }
+      let :facts do
+        { :operatingsystemversion => os }
       end
-      let(:facts) do
-        { operatingsystemversion: os }
+      let(:title) { 'fubar' }
+      let :params do
+        { :version => '3.5', :ensure => 'fubar' }
       end
 
       it do
-        expect do
-          should contain_exec('install-dotnet-3.5')
-        end.to raise_error(Puppet::Error)
+        expect { should contain_exec('install-dotnet-3.5') }.to raise_error(Puppet::Error)
+      end
+    end
+  end
+
+  ['unknown'].each do |release|
+    context "with ensure => present, version => 4.5, os.release.full => #{release}" do
+      let(:title) { 'fubar' }
+      let :params do
+        { :version => '4.5.1', :ensure => 'present' }
+      end
+      let :facts do
+        { :os => { 'family' => 'windows', 'release' => { 'full' => release } } }
+      end
+
+      it do
+        expect { is_expected.to compile }.to raise_error(/is not supported on windows #{release}/)
       end
     end
   end

--- a/spec/defines/three_spec.rb
+++ b/spec/defines/three_spec.rb
@@ -1,241 +1,86 @@
 require 'spec_helper'
-# rubocop:disable RSpec/InstanceVariable
-describe 'dotnet', type: :define do
-  before do
-    @hklm = 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
 
-    @three_url = 'http://download.microsoft.com/download/7/0/3/703455ee-a747-4cc8-bd3e-98a615c3aedb/dotNetFx35setup.exe'
-    @three_prog = 'dotNetFx35setup.exe'
-    @three_reg = '{CE2CDD62-0124-36CA-84D3-9F4DCF5C5BD9}'
+describe 'dotnet', :type => :define do
+  let(:title) { 'dotnet35' }
+  let :params do
+    { :ensure => 'present', :version => '3.5' }
   end
 
-  ['Windows Server 2008', 'Windows Server 2008 R2', 'Windows Server 2012'].each do |os|
-    context "with ensure => present, version => 3.5, os => #{os}, server feature" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'present',
-          version: '3.5'
-        }
-      end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
+  ['2008 R2', '2012', '2012 R2'].each do |release|
+    context "with ensure => present, version => 3.5, os.release.full => #{release}" do
+      let :facts do
+        { :os => { 'family' => 'windows', 'release' => { 'full' => release } } }
       end
 
       it do
-        should contain_exec('install-feature-3.5').with(
-          'provider'  => 'powershell',
-          'logoutput' => 'true',
-          'command'   => 'Import-Module ServerManager; Add-WindowsFeature as-net-framework',
-          'unless'    => 'Test-Path C:\\Windows\\Microsoft.NET\\Framework\\v3.5'
+        should contain_exec('install-dotnet-feature-3.5').with(
+          'provider' => 'powershell',
         )
       end
     end
   end
 
-  ['unknown', 'Windows Server 2003', 'Windows Server 2003 R2'].each do |os|
-    context "with ensure => present, version => 3.5, os => #{os}, server feature" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'present',
-          version: '3.5'
-        }
+  ['2008 R2', '2012', '2012 R2'].each do |release|
+    context "with ensure => absent, version => 3.5, os.release.full => #{release}" do
+      let :params do
+        { :ensure => 'absent', :version => '3.5' }
       end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
-      end
-
-      it { should_not contain_exec('install-feature-3.5') }
-    end
-  end
-
-  ['Windows Server 2008', 'Windows Server 2008 R2', 'Windows Server 2012'].each do |os|
-    context "with ensure => absent, version => 3.5, os => #{os}, server feature" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'absent',
-          version: '3.5'
-        }
-      end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
+      let :facts do
+        { :os => { 'family' => 'windows', 'release' => { 'full' => release } } }
       end
 
       it do
-        should contain_exec('uninstall-feature-3.5').with(
-          'provider'  => 'powershell',
-          'logoutput' => 'true',
-          'command'   => 'Import-Module ServerManager; Remove-WindowsFeature as-net-framework',
-          'onlyif'    => 'Test-Path C:\\Windows\\Microsoft.NET\\Framework\\v3.5'
+        should contain_exec('uninstall-dotnet-feature-3.5').with(
+          'provider' => 'powershell',
         )
       end
     end
   end
 
-  ['Windows XP', 'Windows Vista', 'Windows 7', 'Windows 8'].each do |os|
-    context "with ensure => present, version => 3.5, os => #{os}, network package" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'present',
-          version: '3.5',
-          package_dir: 'C:\\Windows\\Temp'
-        }
-      end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
+  ['2003', '2003 R2', '2008', 'XP', 'Vista', '7', '8', '8.1'].each do |release|
+    context "with ensure => present, version => 3.5, os.release.full => #{release}" do
+      let :facts do
+        { :os => { 'family' => 'windows', 'release' => { 'full' => release } } }
       end
 
       it do
-        should contain_exec('install-dotnet-3.5').with(
-          'provider'  => 'powershell',
-          'logoutput' => 'true',
-          'command'   => "& C:\\Windows\\Temp\\#{@three_prog} /q /norestart",
-          'unless'    => "if ((Get-Item -LiteralPath '#{@hklm}\\#{@three_reg}' " + "-ErrorAction SilentlyContinue).GetValue('DisplayVersion')) { exit 0 }"
+        skip('pending 3.5 package-based install validation and code')
+        should contain_package('Microsoft .NET Framework 3.5').with(
+          'ensure' => 'present',
+        )
+      end
+
+      it do
+        skip('pending 3.5 package-based install validation and code')
+        should contain_remote_file('C:/Windows/Temp/dotNetFx35setup.exe').with(
+          'ensure' => 'present',
         )
       end
     end
   end
 
-  ['Windows XP', 'Windows Vista', 'Windows 7', 'Windows 8'].each do |os|
-    context "with ensure => present, version => 3.5, os => #{os}, download package" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'present',
-          version: '3.5'
-        }
+  ['2003', '2003 R2', '2008', 'XP', 'Vista', '7', '8', '8.1'].each do |release|
+    context "with ensure => absent, version => 3.5, os.release.full => #{release}" do
+      let :params do
+        { :ensure => 'absent', :version => '3.5' }
       end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
+      let :facts do
+        { :os => { 'family' => 'windows', 'release' => { 'full' => release } } }
       end
 
       it do
-        should contain_download_file('download-dotnet-3.5').with(
-          'url'                   => @three_url,
-          'destination_directory' => 'C:\\Windows\\Temp'
+        skip('pending 3.5 package-based install validation and code')
+        should contain_package('Microsoft .NET Framework 3.5').with(
+          'ensure' => 'absent',
         )
       end
 
       it do
-        should contain_exec('install-dotnet-3.5').with(
-          'provider'  => 'powershell',
-          'logoutput' => 'true',
-          'command'   => "& C:\\Windows\\Temp\\#{@three_prog} /q /norestart",
-          'unless'    => "if ((Get-Item -LiteralPath '#{@hklm}\\#{@three_reg}' -ErrorAction SilentlyContinue).GetValue('DisplayVersion')) { exit 0 }"
+        skip('pending 3.5 package-based install validation and code')
+        should contain_remote_file('C:/Windows/Temp/dotNetFx35setup.exe').with(
+          'ensure' => 'absent',
         )
       end
-    end
-  end
-
-  ['unknown'].each do |os|
-    context "with ensure => present, version => 3.5, os => #{os}" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'present',
-          version: '3.5',
-          package_dir: 'C:\\Windows\\Temp'
-        }
-      end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
-      end
-
-      it { should_not contain_exec('install-dotnet-35') }
-    end
-  end
-
-  ['Windows XP', 'Windows Vista', 'Windows 7', 'Windows 8'].each do |os|
-    context "with ensure => absent, version => 3.5, os => #{os}" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'absent',
-          version: '3.5',
-          package_dir: 'C:\\Windows\\Temp'
-        }
-      end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
-      end
-
-      it do
-        should contain_exec('uninstall-dotnet-3.5').with(
-          'provider'  => 'powershell',
-          'logoutput' => 'true',
-          'command'   => "& C:\\Windows\\Temp\\#{@three_prog} /x /q /norestart",
-          'unless'    => "if ((Get-Item -LiteralPath '#{@hklm}\\#{@three_reg}' -ErrorAction SilentlyContinue).GetValue('DisplayVersion')) { exit 1 }"
-        )
-      end
-    end
-  end
-
-  ['Windows XP', 'Windows Vista', 'Windows 7', 'Windows 8'].each do |os|
-    context "with ensure => absent, version => 3.5, os => #{os}, download package" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'absent',
-          version: '3.5'
-        }
-      end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
-      end
-
-      it do
-        should contain_file("C:/Windows/Temp/#{@three_prog}").with(
-          'ensure' => 'absent'
-        )
-      end
-
-      it do
-        should contain_exec('uninstall-dotnet-3.5').with(
-          'provider'  => 'powershell',
-          'logoutput' => 'true',
-          'command'   => "& C:\\Windows\\Temp\\#{@three_prog} /x /q /norestart",
-          'unless'    => "if ((Get-Item -LiteralPath '#{@hklm}\\#{@three_reg}' -ErrorAction SilentlyContinue).GetValue('DisplayVersion')) { exit 1 }"
-        )
-      end
-    end
-  end
-
-  ['unknown'].each do |os|
-    context "with ensure => absent, version => 3.5, os => #{os}" do
-      let(:title) { 'dotnet35' }
-      let(:params) do
-        {
-          ensure: 'absent',
-          version: '3.5',
-          package_dir: 'C:\\Windows\\Temp'
-        }
-      end
-      let(:facts) do
-        {
-          operatingsystemversion: os
-        }
-      end
-
-      it { should_not contain_exec('uninstall-dotnet-3.5') }
     end
   end
 end


### PR DESCRIPTION
This PR is a proposed refactor and major version update. This would be released as a new major version.
- Switch to Puppet 4
  - Use type features for validation, eliminating dependency on puppetlabs/stdlib.
  - Use iteration in dotnet::install::package utility type
  - Use new `$::os` fact
- Switch from puppet/download_file to lwf/remote_file. Per commit message in 4db8e15, primary benefit is cleaner implementation allowing for more reliable notify/subscribe. Especially when reboots are subscribed to a dotnet resource this can be important.
- Switch from exec-based package installation to package resource.
  - Makes it easier to see what dotnet is doing in the graph
  - Makes the code cleaner
