### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name":         "puppet-dotnet",
   "version":      "1.0.2",
   "author":       "puppet-community",
-  "license":      "Apache-2.0",
+  "license":      "MIT",
   "summary":      "'Module to manage the Microsoft .NET framework",
   "source":       "https://github.com/puppet-community/puppet-dotnet",
   "project_page": "https://github.com/puppet-community/puppet-dotnet",


### PR DESCRIPTION
LICENSE file is MIT but metadata.json has had Apache-2.0 for quite
some time